### PR TITLE
fix qrcode timing pattern generator

### DIFF
--- a/qrcode/encoder/matrix_util.go
+++ b/qrcode/encoder/matrix_util.go
@@ -382,7 +382,7 @@ func embedTimingPatterns(matrix *ByteMatrix) {
 	// -8 is for skipping position detection patterns (size 7), and two horizontal/vertical
 	// separation patterns (size 1). Thus, 8 = 7 + 1.
 	for i := 8; i < matrix.GetWidth()-8; i++ {
-		bit := int8(i+1) % 2
+		bit := int8((i + 1) % 2)
 		// Horizontal line.
 		if isEmpty(matrix.Get(i, 6)) {
 			matrix.Set(i, 6, bit)

--- a/qrcode/encoder/matrix_util_test.go
+++ b/qrcode/encoder/matrix_util_test.go
@@ -515,3 +515,28 @@ func TestMatrixUtil_buildMatrix(t *testing.T) {
 		}
 	}
 }
+
+func TestEmbedTimingPatterns(t *testing.T) {
+	version, _ := decoder.Version_GetVersionForNumber(40)
+	dimension := version.GetDimensionForVersion()
+	matrix := NewByteMatrix(dimension, dimension)
+	matrix.Clear(-1)
+
+	embedTimingPatterns(matrix)
+
+	for i := 8; i < matrix.GetWidth()-8; i++ {
+		bit := matrix.Get(i, 6)
+		wants := (i + 1) % 2
+		if bit != int8(wants) {
+			t.Fatalf("matrix(%d,6) = %v, wants %v", i, bit, wants)
+		}
+	}
+
+	for i := 8; i < matrix.GetHeight()-8; i++ {
+		bit := matrix.Get(6, i)
+		wants := (i + 1) % 2
+		if bit != int8(wants) {
+			t.Fatalf("matrix(6, %d) = %v, wants %v", i, bit, wants)
+		}
+	}
+}


### PR DESCRIPTION
fix overflow bug in `qrcode.encoder.embedTimingPatterns`.
reported in #14.