### PR TITLE
datamatrix: first FNC1 as ascii 232

### DIFF
--- a/datamatrix/encoder/high_level_encoder.go
+++ b/datamatrix/encoder/high_level_encoder.go
@@ -20,7 +20,7 @@ const (
 	HighLevelEncoder_LATCH_TO_BASE256 = 231
 
 	// FNC1 Codeword
-	// HighLevelEncoder_FUNC1 = 232
+	HighLevelEncoder_FUNC1 = 232
 
 	// Structured Append Codeword
 	// HighLevelEncoder_STRUCTURED_APPEND = 233
@@ -117,6 +117,11 @@ func EncodeHighLevel(msg string, shape SymbolShapeHint, minSize, maxSize *gozxin
 	}
 	context.SetSymbolShape(shape)
 	context.SetSizeConstraints(minSize, maxSize)
+
+	if strings.HasPrefix(msg, "\u00e8") {
+		context.WriteCodeword(HighLevelEncoder_FUNC1)
+		context.pos += 1
+	}
 
 	if strings.HasPrefix(msg, HighLevelEncoder_MACRO_05_HEADER) &&
 		strings.HasSuffix(msg, HighLevelEncoder_MACRO_TRAILER) {

--- a/datamatrix/encoder/high_level_encoder_test.go
+++ b/datamatrix/encoder/high_level_encoder_test.go
@@ -339,4 +339,14 @@ func TestEncodeHighLevel(t *testing.T) {
 	if !reflect.DeepEqual(b, expect) {
 		t.Fatalf("EncodeHighLevel = %v, expect %v", b, expect)
 	}
+
+	str = "\u00e8a"
+	b, e = EncodeHighLevel(str, shape, nil, nil)
+	expect = []byte{232, 98, 129}
+	if e != nil {
+		t.Fatalf("EncodeHighLevel returns error: %v", e)
+	}
+	if !reflect.DeepEqual(b, expect) {
+		t.Fatalf("EncodeHighLevel = %v, expect %v", b, expect)
+	}
 }


### PR DESCRIPTION
To support GS1 Datamatrix format