### PR TITLE
Optimize luminance sources from *image.Gray, image.RGBA64Image

### DIFF
--- a/go_image_luminance_source.go
+++ b/go_image_luminance_source.go
@@ -22,12 +22,33 @@ func NewLuminanceSourceFromImage(img image.Image) LuminanceSource {
 
 	luminance := make([]byte, width*height)
 	index := 0
-	for y := rect.Min.Y; y < rect.Max.Y; y++ {
-		for x := rect.Min.X; x < rect.Max.X; x++ {
-			r, g, b, a := img.At(x, y).RGBA()
-			lum := (r + 2*g + b) * 255 / (4 * 0xffff)
-			luminance[index] = byte((lum*a + (0xffff-a)*255) / 0xffff)
-			index++
+	// Optimize special cases.
+	switch img := img.(type) {
+	case *image.Gray:
+		for y := rect.Min.Y; y < rect.Max.Y; y++ {
+			for x := rect.Min.X; x < rect.Max.X; x++ {
+				y := img.GrayAt(x, y).Y
+				luminance[index] = y
+				index++
+			}
+		}
+	case image.RGBA64Image:
+		for y := rect.Min.Y; y < rect.Max.Y; y++ {
+			for x := rect.Min.X; x < rect.Max.X; x++ {
+				r, g, b, a := img.RGBA64At(x, y).RGBA()
+				lum := (r + 2*g + b) * 255 / (4 * 0xffff)
+				luminance[index] = byte((lum*a + (0xffff-a)*255) / 0xffff)
+				index++
+			}
+		}
+	default:
+		for y := rect.Min.Y; y < rect.Max.Y; y++ {
+			for x := rect.Min.X; x < rect.Max.X; x++ {
+				r, g, b, a := img.At(x, y).RGBA()
+				lum := (r + 2*g + b) * 255 / (4 * 0xffff)
+				luminance[index] = byte((lum*a + (0xffff-a)*255) / 0xffff)
+				index++
+			}
 		}
 	}
 


### PR DESCRIPTION
This change optimizes two special cases for NewLuminanceSourceFromImage:

1. image.RGBA64Image. The interface was introduced in Go 1.17 and using it avoids the per-pixel allocation of a color.Color interface value.

2. *image.Gray. Special-casing image.Gray is even faster, primarily because it avoids the per-pixel interface call, secondarily because a grayscale image is trivially converted to luminance values.