### PR TITLE
feat: QRコードのデコード時に取得できるメタデータに`ERRORS_CORRECTED`を追加

### DIFF
--- a/common/reedsolomon/reedsolomon_decoder.go
+++ b/common/reedsolomon/reedsolomon_decoder.go
@@ -13,9 +13,14 @@ func NewReedSolomonDecoder(field *GenericGF) *ReedSolomonDecoder {
 }
 
 func (this *ReedSolomonDecoder) Decode(received []int, twoS int) ReedSolomonException {
+	_, e := this.DecodeWithECCount(received, twoS)
+	return e
+}
+
+func (this *ReedSolomonDecoder) DecodeWithECCount(received []int, twoS int) (int, ReedSolomonException) {
 	poly, e := NewGenericGFPoly(this.field, received)
 	if e != nil {
-		return WrapReedSolomonException(e)
+		return 0, WrapReedSolomonException(e)
 	}
 	syndromeCoefficients := make([]int, twoS)
 	noError := true
@@ -27,40 +32,40 @@ func (this *ReedSolomonDecoder) Decode(received []int, twoS int) ReedSolomonExce
 		}
 	}
 	if noError {
-		return nil
+		return 0, nil
 	}
 	syndrome, e := NewGenericGFPoly(this.field, syndromeCoefficients)
 	if e != nil {
-		return WrapReedSolomonException(e)
+		return 0, WrapReedSolomonException(e)
 	}
 	monomial, e := this.field.BuildMonomial(twoS, 1)
 	if e != nil {
-		return WrapReedSolomonException(e)
+		return 0, WrapReedSolomonException(e)
 	}
 	sigma, omega, e := this.runEuclideanAlgorithm(monomial, syndrome, twoS)
 	if e != nil {
-		return WrapReedSolomonException(e)
+		return 0, WrapReedSolomonException(e)
 	}
 	errorLocations, e := this.findErrorLocations(sigma)
 	if e != nil {
-		return WrapReedSolomonException(e)
+		return 0, WrapReedSolomonException(e)
 	}
 	errorMagnitudes, e := this.findErrorMagnitudes(omega, errorLocations)
 	if e != nil {
-		return WrapReedSolomonException(e)
+		return 0, WrapReedSolomonException(e)
 	}
 	for i := 0; i < len(errorLocations); i++ {
 		log, e := this.field.Log(errorLocations[i])
 		if e != nil {
-			return WrapReedSolomonException(e)
+			return 0, WrapReedSolomonException(e)
 		}
 		position := len(received) - 1 - log
 		if position < 0 {
-			return NewReedSolomonException("Bad error location")
+			return 0, NewReedSolomonException("Bad error location")
 		}
 		received[position] = GenericGF_addOrSubtract(received[position], errorMagnitudes[i])
 	}
-	return nil
+	return len(errorLocations), nil
 }
 
 func (this *ReedSolomonDecoder) runEuclideanAlgorithm(a, b *GenericGFPoly, R int) (sigma, omega *GenericGFPoly, e error) {

--- a/qrcode/decoder/decoder.go
+++ b/qrcode/decoder/decoder.go
@@ -130,10 +130,12 @@ func (this *Decoder) decode(parser *BitMatrixParser, hints map[gozxing.DecodeHin
 	resultOffset := 0
 
 	// Error-correct and copy data blocks together into a stream of bytes
+	errorsCorrected := 0
 	for _, dataBlock := range dataBlocks {
 		codewordBytes := dataBlock.GetCodewords()
 		numDataCodewords := dataBlock.GetNumDataCodewords()
-		e := this.correctErrors(codewordBytes, numDataCodewords)
+		c, e := this.correctErrors(codewordBytes, numDataCodewords)
+		errorsCorrected += c
 		if e != nil {
 			return nil, e
 		}
@@ -144,10 +146,15 @@ func (this *Decoder) decode(parser *BitMatrixParser, hints map[gozxing.DecodeHin
 	}
 
 	// Decode the contents of that stream of bytes
-	return DecodedBitStreamParser_Decode(resultBytes, version, ecLevel, hints)
+	result, e := DecodedBitStreamParser_Decode(resultBytes, version, ecLevel, hints)
+	if e != nil {
+		return result, e
+	}
+	result.SetErrorsCorrected(errorsCorrected)
+	return result, nil
 }
 
-func (this *Decoder) correctErrors(codewordBytes []byte, numDataCodewords int) error {
+func (this *Decoder) correctErrors(codewordBytes []byte, numDataCodewords int) (int, error) {
 	numCodewords := len(codewordBytes)
 	// First read into an array of ints
 	codewordsInts := make([]int, numCodewords)
@@ -155,14 +162,16 @@ func (this *Decoder) correctErrors(codewordBytes []byte, numDataCodewords int) e
 		codewordsInts[i] = int(codewordBytes[i] & 0xFF)
 	}
 
-	e := this.rsDecoder.Decode(codewordsInts, numCodewords-numDataCodewords)
+	errorsCorrected := 0
+
+	errorsCorrected, e := this.rsDecoder.DecodeWithECCount(codewordsInts, numCodewords-numDataCodewords)
 	if e != nil {
-		return gozxing.WrapChecksumException(e)
+		return 0, gozxing.WrapChecksumException(e)
 	}
 	// Copy back into array of bytes -- only need to worry about the bytes that were data
 	// We don't care about errors in the error-correction codewords
 	for i := 0; i < numDataCodewords; i++ {
 		codewordBytes[i] = byte(codewordsInts[i])
 	}
-	return nil
+	return errorsCorrected, nil
 }

--- a/qrcode/qrcode_reader.go
+++ b/qrcode/qrcode_reader.go
@@ -80,6 +80,7 @@ func (this *QRCodeReader) Decode(image *gozxing.BinaryBitmap, hints map[gozxing.
 			gozxing.ResultMetadataType_STRUCTURED_APPEND_PARITY,
 			decoderResult.GetStructuredAppendParity())
 	}
+	result.PutMetadata(gozxing.ResultMetadataType_ERRORS_CORRECTED, decoderResult.GetErrorsCorrected())
 	result.PutMetadata(
 		gozxing.ResultMetadataType_SYMBOLOGY_IDENTIFIER, "]Q"+strconv.Itoa(decoderResult.GetSymbologyModifier()))
 	return result, nil

--- a/result_metadata_type.go
+++ b/result_metadata_type.go
@@ -35,6 +35,11 @@ const (
 	ResultMetadataType_ERROR_CORRECTION_LEVEL
 
 	/**
+	 * The number of errors corrected. If applicable, maps to an {@link Integer} of value greater than or equal to zero.
+	 */
+	ResultMetadataType_ERRORS_CORRECTED
+
+	/**
 	 * For some periodicals, indicates the issue number as an {@link Integer}.
 	 */
 	ResultMetadataType_ISSUE_NUMBER
@@ -91,6 +96,8 @@ func (t ResultMetadataType) String() string {
 		return "BYTE_SEGMENTS"
 	case ResultMetadataType_ERROR_CORRECTION_LEVEL:
 		return "ERROR_CORRECTION_LEVEL"
+	case ResultMetadataType_ERRORS_CORRECTED:
+		return "ERRORS_CORRECTED"
 	case ResultMetadataType_ISSUE_NUMBER:
 		return "ISSUE_NUMBER"
 	case ResultMetadataType_SUGGESTED_PRICE:


### PR DESCRIPTION
はじめまして
プロフィールを拝見する限り日本の方のようでしたので、日本語で失礼します。

GoでQRコードのデコードができるライブラリがないか探していたところ、このライブラリを見つけました。Javaのzxingを移植されているとのことで、まさしく私が必要としているものでした。ありがとうございます。

実際に使ってみると、本家では取得できる`ERRORS_CORRECTED`がメタデータに含まれていないことに気が付きました。
2023年ごろに追加された機能なので、まだ実装していないのだと思います。
https://github.com/zxing/zxing/pull/1657

私の用途ではQRコードしか使わない予定なのでいったんその箇所だけ実装してみました。
もし問題なければマージしていただけると幸いです！
（本家のPR同様、ほかのフォーマットの実装も必要でしたら教えてください。）

よろしくお願いいたします。