### PR TITLE
Fix: add mutex to GlobalHistogramBinarizer for concurrent access safety

### DIFF
--- a/global_histogram_binarizer.go
+++ b/global_histogram_binarizer.go
@@ -1,5 +1,7 @@
 package gozxing
 
+import "sync"
+
 const (
 	LUMINANCE_BITS    = 5
 	LUMINANCE_SHIFT   = 8 - LUMINANCE_BITS
@@ -7,6 +9,7 @@ const (
 )
 
 type GlobalHistogramBinarizer struct {
+	mu         sync.Mutex
 	source     LuminanceSource
 	luminances []byte
 	buckets    []int
@@ -33,6 +36,9 @@ func (this *GlobalHistogramBinarizer) GetHeight() int {
 }
 
 func (this *GlobalHistogramBinarizer) GetBlackRow(y int, row *BitArray) (*BitArray, error) {
+	this.mu.Lock()
+	defer this.mu.Unlock()
+
 	source := this.GetLuminanceSource()
 	width := source.GetWidth()
 	if row == nil || row.GetSize() < width {
@@ -79,6 +85,9 @@ func (this *GlobalHistogramBinarizer) GetBlackRow(y int, row *BitArray) (*BitArr
 }
 
 func (this *GlobalHistogramBinarizer) GetBlackMatrix() (*BitMatrix, error) {
+	this.mu.Lock()
+	defer this.mu.Unlock()
+
 	source := this.GetLuminanceSource()
 	width := source.GetWidth()
 	height := source.GetHeight()


### PR DESCRIPTION
## Summary

- Add `sync.Mutex` to `GlobalHistogramBinarizer` to protect `GetBlackRow()` and `GetBlackMatrix()` from concurrent access
- Both methods mutate shared `luminances` and `buckets` fields via `initArrays()` with no synchronization, chains data races under concurrent use

## Context

This complements PR #75 (`sync.Once` on `GetBlackMatrix`) and PR #81 (`BitMatrix.Clone` in parser). Together they address the three concurrent access points in the decode pipeline.

## Testing

- [x] All existing test packages pass, apart from an upstream, unrelated failure in `TestDefaultGridSampler_SampleGrid` of course